### PR TITLE
Add blog layout for backblasts

### DIFF
--- a/backblasts.html
+++ b/backblasts.html
@@ -40,10 +40,53 @@
   <div class="tagline">Fitness. Fellowship. Faith.</div>
 
   <main>
-    <section>
-      <h2>Backblasts</h2>
-      <p>Content for the Backblasts page.</p>
-    </section>
+    <div class="blog-container">
+      <div class="blog-main">
+        <article class="blog-card">
+          <img src="https://via.placeholder.com/80" alt="Backblast thumbnail">
+          <div>
+            <h3>All About the Burpees</h3>
+            <p class="meta">May 20, 2024 &mdash; Woods Park</p>
+            <p class="preview">Great turnout with 20 PAX at Woods Park for a burpee-heavy beatdown led by Ponzi.</p>
+            <a class="read-more" href="#">Read More</a>
+          </div>
+        </article>
+        <article class="blog-card">
+          <img src="https://via.placeholder.com/80" alt="Backblast thumbnail">
+          <div>
+            <h3>Sunrise Sprints at Pioneers Park</h3>
+            <p class="meta">May 15, 2024 &mdash; Pioneers Park</p>
+            <p class="preview">Speed work on the hills challenged the group and set a fast pace for the day.</p>
+            <a class="read-more" href="#">Read More</a>
+          </div>
+        </article>
+        <article class="blog-card">
+          <img src="https://via.placeholder.com/80" alt="Backblast thumbnail">
+          <div>
+            <h3>First Monday Murph</h3>
+            <p class="meta">May 6, 2024 &mdash; Antelope Park</p>
+            <p class="preview">We honored our servicemen with a classic Murph workout. Strong effort from all.</p>
+            <a class="read-more" href="#">Read More</a>
+          </div>
+        </article>
+      </div>
+      <aside class="sidebar">
+        <input type="text" placeholder="Search...">
+        <h3>Recent Posts</h3>
+        <ul class="recent-posts">
+          <li><a href="#">All About the Burpees</a></li>
+          <li><a href="#">Sunrise Sprints at Pioneers Park</a></li>
+          <li><a href="#">First Monday Murph</a></li>
+        </ul>
+        <div class="social-icons">
+          <span>🌐</span> <span>🐦</span> <span>📘</span>
+        </div>
+        <div class="about-snippet">
+          <h3>About F3 Omaha</h3>
+          <p>F3 Omaha exists to plant, grow and serve small workout groups for men for the invigoration of male community leadership.</p>
+        </div>
+      </aside>
+    </div>
   </main>
 
   <footer>

--- a/css/styles.css
+++ b/css/styles.css
@@ -295,3 +295,91 @@ footer {
   width: 100%;
   max-width: 300px;
 }
+
+/* Blog layout */
+.blog-container {
+  display: flex;
+  align-items: flex-start;
+}
+
+.blog-main {
+  flex: 3;
+}
+
+.blog-card {
+  display: flex;
+  background: #fff;
+  border: 1px solid #ddd;
+  margin-bottom: 20px;
+  padding: 10px;
+}
+
+.blog-card img {
+  width: 80px;
+  height: 80px;
+  object-fit: cover;
+  margin-right: 10px;
+}
+
+.blog-card h3 {
+  margin: 0 0 5px;
+}
+
+.blog-card .meta {
+  font-size: 0.9em;
+  color: #777;
+}
+
+.blog-card .read-more {
+  color: #0049d1;
+  text-decoration: none;
+  font-weight: bold;
+}
+
+.sidebar {
+  flex: 1;
+  margin-left: 20px;
+}
+
+.sidebar input[type="text"] {
+  width: 100%;
+  padding: 6px;
+  margin-bottom: 20px;
+}
+
+.recent-posts {
+  list-style: none;
+  padding: 0;
+}
+
+.recent-posts li {
+  margin-bottom: 5px;
+}
+
+.recent-posts a {
+  color: #0049d1;
+  text-decoration: none;
+}
+
+.social-icons {
+  margin: 20px 0;
+}
+
+@media (max-width: 800px) {
+  .blog-container {
+    flex-direction: column;
+  }
+  .sidebar {
+    margin-left: 0;
+    margin-top: 20px;
+  }
+  .blog-card {
+    flex-direction: column;
+    text-align: center;
+  }
+  .blog-card img {
+    width: 100%;
+    height: auto;
+    margin: 0 0 10px;
+  }
+}


### PR DESCRIPTION
## Summary
- implement blog-style cards and sidebar on Backblasts page
- add accompanying CSS for blog layout

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68819735e22c833192ebeedb4e284fc8